### PR TITLE
Fix: Update button hover animation to pink and reduce flickering

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -59,7 +59,7 @@
     border-radius: 31px;
     cursor: pointer;
     border: 1px solid white;
-    background-image: none;
+    background-image: var(--accent-gradient);
     background-size: 400%;
     background-position: 100%;
     transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -66,11 +66,12 @@ const { title } = Astro.props;
 		--accent-light: 224, 204, 250;
 		--accent-dark: 49, 10, 101;
 		--accent-dusk: 114, 23, 232;
+		--accent-pink: 255, 105, 180;
 		--accent-gradient: linear-gradient(
 			45deg,
 			rgb(var(--accent)),
 			rgb(var(--accent-light)) 30%,
-			rgb(4, 214, 246) 60%
+			rgb(var(--accent-pink)) 60%
 		);
 	}
 	html {


### PR DESCRIPTION
- I modified the CSS variable `--accent-gradient` in `src/layouts/Layout.astro` to replace the final blue color stop with a new pink color (`--accent-pink`).
- I updated the `.contact__resume-button` style in `src/components/Contact.astro` to apply the gradient background by default, rather than only on hover. This aims to create a smoother animation by only transitioning the `background-position`.

The "Get my resume" button's hover animation should now end with a pink hue instead of blue at one of its gradient extremes, and the animation should appear less prone to flickering.